### PR TITLE
Configure aicoe-ci yaml to build image and push to quay

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -3,14 +3,15 @@
 check:
   - thoth-precommit
   # Uncomment following line to build a public image of this repo
-  # - thoth-build
+  - thoth-build
 
 # Uncomment following lines to build a public image of this repo
-# build:
-#   build-stratergy: Source
-#   build-source-script: "image:///opt/app-root/builder"
-#   base-image: quay.io/thoth-station/s2i-custom-notebook:latest
-#   registry: quay.io
-#   registry-org: aicoe
-#   registry-project: <CHANGE-ME>
-#   registry-secret: aicoe-pusher-secret
+build:
+  build-stratergy: Source
+  build-source-script: "image:///opt/app-root/builder"
+  base-image: quay.io/thoth-station/s2i-custom-notebook:latest
+  custom-tag: latest
+  registry: quay.io
+  registry-org: aicoe
+  registry-project: openshift-anomaly-detection
+  registry-secret: aicoe-pusher-secret


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Updates aicoe-ci config file

## Description

This PR configures aicoe-ci on this repo to create s2i image and push to the quay repo [here](https://quay.io/repository/aicoe/openshift-anomaly-detection). Once build is triggered and image is built, it can then be deployed to MOC or internal JH