### PR TITLE
Fix inconsistent timestamp error

### DIFF
--- a/notebooks/stage/anomaly-detection-demo.ipynb
+++ b/notebooks/stage/anomaly-detection-demo.ipynb
@@ -161,6 +161,7 @@
     "        hour=hour,\n",
     "        minute=minute,\n",
     "        second=second,\n",
+    "        tzinfo=dt.timezone.utc,\n",
     "    )\n",
     "    query_eval_timestamp = query_eval_time.timestamp()\n",
     "\n",
@@ -4219,9 +4220,9 @@
    "trusted": true
   },
   "kernelspec": {
-   "display_name": "openshift-anomaly-detection",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "openshift-anomaly-detection"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -4233,7 +4234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.12"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Explicitly specify timezone when querying prometheus

## Description

When notebook is run on a machine (e.g. my laptop) other than Red Hat internal JH then timestamp resolves to a different value because the specified datetime gets resolved to use the local time zone (instead of UTC). Because of this, the caching function thinks the query is for a different timestamp, even though it is for the same one. Specifying tzinfo will fix this.