### PR TITLE
Update precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: git://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.1.10
     hooks:
       - id: remove-tabs
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -23,12 +23,12 @@ repos:
       - id: debug-statements
 
   - repo: git://github.com/pycqa/pydocstyle.git
-    rev: 5.1.1
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.1.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -36,19 +36,19 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.931
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.12b0
     hooks:
       - id: black
 
   - repo: https://github.com/tomcatling/black-nb
-    rev: '0.3.0'
+    rev: '0.6'
     hooks:
       - id: black-nb
 
@@ -59,7 +59,7 @@ repos:
   #     - id: check-manifest
 
   - repo: https://github.com/s-weigand/flake8-nb
-    rev: v0.2.5
+    rev: v0.3.1
     hooks:
       - id: flake8-nb
         additional_dependencies: ['pep8-naming']


### PR DESCRIPTION
## Related Issues and Dependencies

None

## This introduces a breaking change

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

The precommit hooks are quite outdated on this repo. This might be causing some CI check failures such as [this one](https://github.com/aicoe-aiops/openshift-anomaly-detection/pull/30#issuecomment-1008994611). This PR updates precommit hooks to latest versions.